### PR TITLE
Update the name of the gem to 'mautic' in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ RoR helper / wrapper for Mautic API and forms. But it is using Redis instead of 
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'mautic-redis', github: 'TheDartsCo/mautic-redis-rails'
+gem 'mautic', github: 'TheDartsCo/mautic-redis-rails'
 ```
 
 ### Configure

--- a/lib/mautic/model.rb
+++ b/lib/mautic/model.rb
@@ -46,7 +46,7 @@ module Mautic
 
       def create(connection, params = {})
         begin
-          json = connection.request(:post, "api/#{endpoint}/#{id && "#{id}/"}new", { body: params })
+          json = connection.request(:post, "api/#{endpoint}/new", { body: params })
 
           instance = new(connection, json[field_name.singularize])
         rescue ValidationError => e

--- a/lib/mautic/model.rb
+++ b/lib/mautic/model.rb
@@ -46,7 +46,8 @@ module Mautic
 
       def create(connection, params = {})
         begin
-          json = connection.request(:post, "api/#{endpoint}/new", body: params)
+          json = connection.request(:post, "api/#{endpoint}/#{id && "#{id}/"}new", { body: params })
+
           instance = new(connection, json[field_name.singularize])
         rescue ValidationError => e
           if instance.nil?


### PR DESCRIPTION
Installation instructions in README file must refer to the new name of the gem which is 'mautic' instead of 'mautic-redis' to avoid errors while installing the gem just like that error:
"The source does not contain any versions of 'mautic-redis' "